### PR TITLE
Added features for custom CodingKeys.

### DIFF
--- a/Sources/DocumentData/DocumentData.swift
+++ b/Sources/DocumentData/DocumentData.swift
@@ -96,3 +96,5 @@ public macro _PersistedIgnored() = #externalMacro(module: "DocumentDataMacros", 
 @attached(peer, names: named(_$persistedDocumentName))
 public macro StorageName() = #externalMacro(module: "DocumentDataMacros", type: "StorageNameMacro")
 
+@attached(peer, names: named(_$PersistedCodingKeys))
+public macro ModelCodingKey() = #externalMacro(module: "DocumentDataMacros", type: "ModelCodingKeyMacro")

--- a/Sources/DocumentData/DocumentData.swift
+++ b/Sources/DocumentData/DocumentData.swift
@@ -96,5 +96,46 @@ public macro _PersistedIgnored() = #externalMacro(module: "DocumentDataMacros", 
 @attached(peer, names: named(_$persistedDocumentName))
 public macro StorageName() = #externalMacro(module: "DocumentDataMacros", type: "StorageNameMacro")
 
+/// Make current property as the coding keys fo persistence file.
+///
+/// This macro allow you customize the default coding keys. This is a example for model names with `UserProfile`.
+///
+/// ```swift
+/// @PersistedModel
+/// final class UserProfile {
+///     var username: String
+///     var password: Data
+/// }
+/// ```
+///
+/// The default coding key should be like this:
+///
+/// ```swift
+/// enum _$PersistedCodingKeys: String, CodingKey {
+///     case _username = "username"
+///     case _password = "password"
+/// }
+/// ```
+///
+/// Use `@ModelCodingKey` can mutate the default behavior. To reach this,
+/// developer should provide a coding key enumrator with the name **has no underline (`_`)**.
+///
+/// ```swift
+/// @ModelCodingKey
+/// enum CustomizeCodingKey: String, CodingKey {
+///     case username = "FILUsername"
+///     case password = "USRPassword"
+/// }
+/// ```
+///
+/// Macro will help you take care of the rest.
+///
+/// - Important: Always make sure that every property is included in the custom CodingKey.
+///
+/// Some property should not contains in your customize coding key:
+/// - Customize file name (`@StorageName`)
+/// - `@PersistedIgnored` properties
+///
+/// - Warning: Any of the above properties exist in custom coding key may cause unexpected errors.
 @attached(peer, names: named(_$PersistedCodingKeys))
 public macro ModelCodingKey() = #externalMacro(module: "DocumentDataMacros", type: "ModelCodingKeyMacro")

--- a/Sources/DocumentData/Documentation.docc/CodeTemplate.md
+++ b/Sources/DocumentData/Documentation.docc/CodeTemplate.md
@@ -223,3 +223,14 @@ var _<#PROPERTY NAME#>: <#PROPERTY TYPE#>
 ```swift
 @_PersistedIgnored private static let _$persistedDocumentName = "<#Initializer Value#>.storage.plist"
 ```
+
+## @ModelCodingKey Examples
+
+### Peer Property
+
+```swift
+enum _$PersistedCodingKeys: String, Codable {
+    case _<#PROPERTY NAME#> = <#CUSTOM NAME#>
+    ...
+}
+```

--- a/Sources/DocumentData/Documentation.docc/DocumentData.md
+++ b/Sources/DocumentData/Documentation.docc/DocumentData.md
@@ -41,3 +41,4 @@ of your application Container.
 ### Customize Your Model
 
 - ``StorageName()``
+- ``ModelCodingKey()``

--- a/Sources/DocumentData/Documentation.docc/OperatingPrinciple/MacroExpansionAnalysis.md
+++ b/Sources/DocumentData/Documentation.docc/OperatingPrinciple/MacroExpansionAnalysis.md
@@ -47,3 +47,8 @@ By the way, ``PersistedProperty()`` will also generate a peer property with slas
 ``PersistedIgnored()`` will make a property observable but not persisted.
 
 The methods will generate are **very similar** with ``PersistedProperty()`` generated, but have no persistece commands. For details, view <doc:CodeTemplate>.
+
+### Expansion of @ModelCodingKey
+
+``ModelCodingKey()`` will generate a `_$PersistedCodingKeys` enumrate property that can replace the default behavior of ``PersistedModel()``'s expansion, 
+and generate a `_$PersistedCodingKeys` property which based on user's customize.

--- a/Sources/DocumentDataMacros/MacroMain.swift
+++ b/Sources/DocumentDataMacros/MacroMain.swift
@@ -16,5 +16,6 @@ struct DocumentDataPlugin: CompilerPlugin {
         PersistedIgnoredMacro.self,
         ObservationPersistedIgnoredMacro.self,
         StorageNameMacro.self,
+        ModelCodingKeyMacro.self,
     ]
 }

--- a/Sources/DocumentDataMacros/PersistedModel/ModelCodingKeyMacro.swift
+++ b/Sources/DocumentDataMacros/PersistedModel/ModelCodingKeyMacro.swift
@@ -18,21 +18,17 @@ extension ModelCodingKeyMacro: PeerMacro {
         providingPeersOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        // TODO: Implementation
         guard let decl = declaration.as(EnumDeclSyntax.self) else {
-            // TODO: Error handling
-            return []
+            throw PersistedModelError.onlyAvailableForEnum
         }
         
         guard let inheritanceClause = decl.inheritanceClause else {
-            // TODO: Error handling
-            return []
+            throw PersistedModelError.cannotFindInheritanceClause
         }
         
-        // check whether the enum comforms to CodingKey
+        // check whether the enum conforms to CodingKey
         guard inheritanceClause.inheritedTypes.contains(where: { $0.type.as(IdentifierTypeSyntax.self)?.name.text == "CodingKey" }) else {
-            // TODO: Error handling
-            return []
+            throw PersistedModelError.notConformsToCodingKey
         }
         
         let members = decl.memberBlock.members
@@ -53,7 +49,6 @@ extension ModelCodingKeyMacro: PeerMacro {
         // extract key and name from syntax
         try members.forEach {
             guard let enumCase = $0.decl.as(EnumCaseDeclSyntax.self) else {
-                // TODO: Error handling
                 throw PersistedModelError.errorOccurredWhileExpanding(functionName: "memberTranslator")
             }
             

--- a/Sources/DocumentDataMacros/PersistedModel/ModelCodingKeyMacro.swift
+++ b/Sources/DocumentDataMacros/PersistedModel/ModelCodingKeyMacro.swift
@@ -1,0 +1,24 @@
+//
+//  ModelCodingKeyMacro.swift
+//
+//
+//  Created by Akivili Collindort on 2024/1/28.
+//
+
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct ModelCodingKeyMacro { }
+
+extension ModelCodingKeyMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        // TODO: Implementation
+        return []
+    }
+}

--- a/Sources/DocumentDataMacros/PersistedModel/ModelCodingKeyMacro.swift
+++ b/Sources/DocumentDataMacros/PersistedModel/ModelCodingKeyMacro.swift
@@ -19,6 +19,56 @@ extension ModelCodingKeyMacro: PeerMacro {
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
         // TODO: Implementation
-        return []
+        guard let decl = declaration.as(EnumDeclSyntax.self) else {
+            // TODO: Error handling
+            return []
+        }
+        
+        guard let inheritanceClause = decl.inheritanceClause else {
+            // TODO: Error handling
+            return []
+        }
+        
+        // check whether the enum comforms to CodingKey
+        guard inheritanceClause.inheritedTypes.contains(where: { $0.type.as(IdentifierTypeSyntax.self)?.name.text == "CodingKey" }) else {
+            // TODO: Error handling
+            return []
+        }
+        
+        let members = decl.memberBlock.members
+        
+        
+        return [
+            """
+            enum _$PersistedCodingKeys\(raw: inheritanceClause.description){
+            \(raw: try memberTranslator(members))
+            }
+            """
+        ]
+    }
+    
+    private static func memberTranslator(_ members: MemberBlockItemListSyntax) throws -> String {
+        var result = [String]()
+        
+        // extract key and name from syntax
+        try members.forEach {
+            guard let enumCase = $0.decl.as(EnumCaseDeclSyntax.self) else {
+                // TODO: Error handling
+                throw PersistedModelError.errorOccurredWhileExpanding(functionName: "memberTranslator")
+            }
+            
+            try enumCase.elements.forEach { caseElement in
+                guard let literalExpr = caseElement.rawValue?.value.description else {
+                    throw PersistedModelError.errorOccurredWhileExpanding(functionName: "memberTranslator")
+                }
+                
+                result.append(
+                    "case _\(caseElement.name.text) = \(literalExpr)"
+                )
+            }
+        }
+        
+        result = result.map { "    " + $0 }
+        return result.joined(separator: "\n")
     }
 }

--- a/Sources/DocumentDataMacros/PersistedModel/PersistedModelError.swift
+++ b/Sources/DocumentDataMacros/PersistedModel/PersistedModelError.swift
@@ -43,6 +43,15 @@ enum PersistedModelError: CustomStringConvertible, Error {
     /// This error may occurred when @PersistedModel attached on a non-final class.
     case unavailableForNonFinalClass
     
+    /// This error may occurred when macro only available for enumrate.
+    case onlyAvailableForEnum
+    
+    /// This error may occurred when macro cannot find inheretance clause.
+    case cannotFindInheritanceClause
+    
+    /// This error may occurred when @ModelCodingKey applied enum not conforms to CodingKey.
+    case notConformsToCodingKey
+    
     var description: String {
         switch self {
         case .unavaliableApplyingType:
@@ -65,6 +74,12 @@ enum PersistedModelError: CustomStringConvertible, Error {
             return "@StorageName only available for static property."
         case .unavailableForNonFinalClass:
             return "@PersistedModel only available for final class."
+        case .onlyAvailableForEnum:
+            return "@ModelCodingKey can only applied on enumrate property."
+        case .cannotFindInheritanceClause:
+            return "Cannot find inheritance clause."
+        case .notConformsToCodingKey:
+            return "This enum does not conforms to CodingKey."
         }
     }
 }

--- a/Tests/DocumentDataIntergrationTests/DocumentDataIntergrationTests.swift
+++ b/Tests/DocumentDataIntergrationTests/DocumentDataIntergrationTests.swift
@@ -66,6 +66,18 @@ final class TestClass {
     @PersistedIgnored
     var ignored: String
     
+    @ModelCodingKey
+    enum CodingKeys: String, CodingKey {
+        case number = "N"
+        case string = "S"
+        case bool = "B"
+        case data = "D"
+        case uuid = "U"
+        case array = "A"
+        case dict = "I"
+        case anyCodable = "E"
+    }
+    
     init(number: Int, string: String, bool: Bool, data: Data, uuid: UUID, array: [String], dict: [String : UUID], anyCodable: AnyCodable, ignored: String) {
         self.number = number
         self.string = string

--- a/Tests/DocumentDataTests/DocumentDataTests.swift
+++ b/Tests/DocumentDataTests/DocumentDataTests.swift
@@ -325,4 +325,24 @@ final class DocumentDataTests: XCTestCase {
         throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
+    
+    func testModelCodingKeyNotConform() throws {
+        #if canImport(DocumentDataMacros)
+        assertMacroExpansion(
+            """
+            @ModelCodingKey
+            enum CodingKeys: String { }
+            """,
+            expandedSource: """
+            enum CodingKeys: String { }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "This enum does not conforms to CodingKey.", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
 }

--- a/Tests/DocumentDataTests/DocumentDataTests.swift
+++ b/Tests/DocumentDataTests/DocumentDataTests.swift
@@ -241,7 +241,7 @@ final class DocumentDataTests: XCTestCase {
         #endif
     }
     
-    func testModelCodingKeyMacroExpansion() throws {
+    func testModelCodingKeyMacroExpansionWithEachLineOne() throws {
         #if canImport(DocumentDataMacros)
         assertMacroExpansion(
             """
@@ -263,6 +263,60 @@ final class DocumentDataTests: XCTestCase {
                 case _string = "DDString"
                 case _uuid = "DDUUID"
                 case _integer = "DDInteger"
+            }
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+    
+    func testModelCodingKeyMacroExpansionWithEachLineMany() throws {
+        #if canImport(DocumentDataMacros)
+        assertMacroExpansion(
+            """
+            @ModelCodingKey
+            enum CodingKeys: String, CodingKey {
+                case string = "DDString", uuid = "DDUUID", integer = "DDInteger"
+            }
+            """,
+            expandedSource: """
+            enum CodingKeys: String, CodingKey {
+                case string = "DDString", uuid = "DDUUID", integer = "DDInteger"
+            }
+            
+            enum _$PersistedCodingKeys: String, CodingKey {
+                case _string = "DDString"
+                case _uuid = "DDUUID"
+                case _integer = "DDInteger"
+            }
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+    
+    func testModelCodingKeyMacroExpansionInIntKey() throws {
+        #if canImport(DocumentDataMacros)
+        assertMacroExpansion(
+            """
+            @ModelCodingKey
+            enum CodingKeys: Int, CodingKey {
+                case string = 1, uuid = 2, integer = 3
+            }
+            """,
+            expandedSource: """
+            enum CodingKeys: Int, CodingKey {
+                case string = 1, uuid = 2, integer = 3
+            }
+            
+            enum _$PersistedCodingKeys: Int, CodingKey {
+                case _string = 1
+                case _uuid = 2
+                case _integer = 3
             }
             """,
             macros: testMacros

--- a/Tests/DocumentDataTests/DocumentDataTests.swift
+++ b/Tests/DocumentDataTests/DocumentDataTests.swift
@@ -12,7 +12,8 @@ let testMacros: [String: Macro.Type] = [
     "PersistedProperty": PersistedPropertyMacro.self,
     "_PersistedIgnored": PersistedIgnoredMacro.self,
     "StorageName": StorageNameMacro.self,
-    "PersistedIgnored": ObservationPersistedIgnoredMacro.self
+    "PersistedIgnored": ObservationPersistedIgnoredMacro.self,
+    "ModelCodingKey": ModelCodingKeyMacro.self
 ]
 #endif
 
@@ -233,6 +234,37 @@ final class DocumentDataTests: XCTestCase {
                     fixIts: [FixItSpec(message: #"Use "let" instead of "var"."#)]
                 )
             ],
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+    
+    func testModelCodingKeyMacroExpansion() throws {
+        #if canImport(DocumentDataMacros)
+        assertMacroExpansion(
+            """
+            @ModelCodingKey
+            enum CodingKeys: String, CodingKey {
+                case string = "DDString"
+                case uuid = "DDUUID"
+                case integer = "DDInteger"
+            }
+            """,
+            expandedSource: """
+            enum CodingKeys: String, CodingKey {
+                case string = "DDString"
+                case uuid = "DDUUID"
+                case integer = "DDInteger"
+            }
+            
+            enum _$PersistedCodingKeys: String, CodingKey {
+                case _string = "DDString"
+                case _uuid = "DDUUID"
+                case _integer = "DDInteger"
+            }
+            """,
             macros: testMacros
         )
         #else

--- a/Tests/DocumentDataTests/DocumentDataTests.swift
+++ b/Tests/DocumentDataTests/DocumentDataTests.swift
@@ -107,6 +107,11 @@ final class DocumentDataTests: XCTestCase {
                     self.textFieldText = textFieldText
                     self.ignoredButObservedToggle = ignoredButObservedToggle
                 }
+            
+                enum _$PersistedCodingKeys: String, CodingKey {
+                    case _isFirstToggleOpen = "isFirstToggleOpen"
+                    case _textFieldText = "textFieldText"
+                }
                 private let _$observationRegistrar = Observation.ObservationRegistrar()
 
                 func encode(to encoder: Encoder) throws {
@@ -120,11 +125,6 @@ final class DocumentDataTests: XCTestCase {
                     self._isFirstToggleOpen = try container.decode(Bool.self, forKey: ._isFirstToggleOpen)
                     self._textFieldText = try container.decode(String.self, forKey: ._textFieldText)
                     self.ignoredButObservedToggle = .init()
-                }
-
-                enum _$PersistedCodingKeys: String, CodingKey {
-                    case _isFirstToggleOpen = "isFirstToggleOpen"
-                    case _textFieldText = "textFieldText"
                 }
 
                 func access<T>(_ keyPath: KeyPath<StoringData, T>) -> T where T: Codable {
@@ -339,6 +339,163 @@ final class DocumentDataTests: XCTestCase {
             diagnostics: [
                 DiagnosticSpec(message: "This enum does not conforms to CodingKey.", line: 1, column: 1)
             ],
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+    
+    func testPersisitedModelMacroExpansionWithCustomCodingKey() throws {
+        #if canImport(DocumentDataMacros)
+        assertMacroExpansion(
+            """
+            @PersistedModel
+            final class StoringData {
+                var isFirstToggleOpen: Bool
+                var textFieldText: String
+                
+                @ModelCodingKey
+                enum CodingKeys: String, CodingKey {
+                    case isFirstToggleOpen = "Toggle"
+                    case textFieldText = "Field"
+                }
+                
+                init(isFirstToggleOpen: Bool, textFieldText: String) {
+                    self.isFirstToggleOpen = isFirstToggleOpen
+                    self.textFieldText = textFieldText
+                }
+            }
+            """,
+            expandedSource: #"""
+            final class StoringData {
+                var isFirstToggleOpen: Bool {
+                    @storageRestrictions(initializes: _isFirstToggleOpen)
+                    init {
+                        _isFirstToggleOpen = newValue
+                    }
+                    get {
+                        access(keyPath: \.isFirstToggleOpen)
+                        return access(\._isFirstToggleOpen)
+                    }
+                    set {
+                        withMutation(keyPath: \.isFirstToggleOpen) {
+                            _isFirstToggleOpen = newValue
+                            self.save()
+                        }
+                    }
+                }
+
+                private var _isFirstToggleOpen: Bool
+                var textFieldText: String {
+                    @storageRestrictions(initializes: _textFieldText)
+                    init {
+                        _textFieldText = newValue
+                    }
+                    get {
+                        access(keyPath: \.textFieldText)
+                        return access(\._textFieldText)
+                    }
+                    set {
+                        withMutation(keyPath: \.textFieldText) {
+                            _textFieldText = newValue
+                            self.save()
+                        }
+                    }
+                }
+
+                private var _textFieldText: String
+                
+                enum CodingKeys: String, CodingKey {
+                    case isFirstToggleOpen = "Toggle"
+                    case textFieldText = "Field"
+                }
+            
+                enum _$PersistedCodingKeys: String, CodingKey {
+                    case _isFirstToggleOpen = "Toggle"
+                    case _textFieldText = "Field"
+                }
+                
+                init(isFirstToggleOpen: Bool, textFieldText: String) {
+                    self.isFirstToggleOpen = isFirstToggleOpen
+                    self.textFieldText = textFieldText
+                }
+            
+                private static let _$persistedDocumentName = "StoringData.storage.plist"
+                private let _$observationRegistrar = Observation.ObservationRegistrar()
+
+                func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: _$PersistedCodingKeys.self)
+                    try container.encode(_isFirstToggleOpen, forKey: ._isFirstToggleOpen)
+                    try container.encode(_textFieldText, forKey: ._textFieldText)
+                }
+
+                required init(from decoder: Decoder) throws {
+                    let container = try decoder.container(keyedBy: _$PersistedCodingKeys.self)
+                    self._isFirstToggleOpen = try container.decode(Bool.self, forKey: ._isFirstToggleOpen)
+                    self._textFieldText = try container.decode(String.self, forKey: ._textFieldText)
+                }
+
+                func access<T>(_ keyPath: KeyPath<StoringData, T>) -> T where T: Codable {
+                    if !Foundation.FileManager.default.fileExists(atPath: Self.url.path(percentEncoded: false)) {
+                        self.save()
+                    }
+
+                    let data = try! Data(contentsOf: Self.url)
+
+                    let decoder = Foundation.PropertyListDecoder()
+
+                    let decoded = try! decoder.decode(StoringData.self, from: data)
+                    return decoded[keyPath: keyPath]
+                }
+
+                func save() {
+                    let encoder = PropertyListEncoder()
+                    encoder.outputFormat = .binary
+
+                    let encoded = try! encoder.encode(self)
+                    try! encoded.write(to: Self.url)
+                }
+
+                internal nonisolated func access<Member>(
+                    keyPath: KeyPath<StoringData, Member>
+                ) {
+                    _$observationRegistrar.access(self, keyPath: keyPath)
+                }
+
+                internal nonisolated func withMutation<Member, MutationResult>(
+                    keyPath: KeyPath<StoringData, Member>,
+                    _ mutation: () throws -> MutationResult
+                ) rethrows -> MutationResult {
+                    try _$observationRegistrar.withMutation(of: self, keyPath: keyPath, mutation)
+                }
+
+                static var `default`: StoringData {
+                    let data = try! Data(contentsOf: Self.url)
+                    let decoder = Foundation.PropertyListDecoder()
+                    return try! decoder.decode(StoringData.self, from: data)
+                }
+
+                static var isPersisted: Bool {
+                    let fileManager = Foundation.FileManager()
+                    return fileManager.fileExists(atPath: Self.url.path(percentEncoded: false))
+                }
+            
+                static var url: URL {
+                    Foundation.URL(filePath: Foundation.NSHomeDirectory())
+                        .appending(components: "Library", "Application Support", _$persistedDocumentName)
+                }
+            }
+
+            extension StoringData: Observation.Observable {
+            }
+
+            extension StoringData: Codable {
+            }
+
+            extension StoringData: DocumentData.DocumentPersistedModel {
+            }
+            """#,
             macros: testMacros
         )
         #else


### PR DESCRIPTION
Now new macro `@ModelCodingKey` allow developer customize the coding key of the persistence model.