### PR TITLE
Fixed an issue that could cause an error when calling save().

### DIFF
--- a/Sources/DocumentDataMacros/PersistedModel/PersistedModelMacro.swift
+++ b/Sources/DocumentDataMacros/PersistedModel/PersistedModelMacro.swift
@@ -90,7 +90,15 @@ extension PersistedModelMacro: MemberMacro {
             
             // save
             """
-            func save() {
+            func save(autoCreateFolder: Bool = true) {
+                if autoCreateFolder {
+                    let fileManager = FileManager()
+                    let applicationSupportURL = Self.url.deletingLastPathComponent()
+                    if !fileManager.fileExists(atPath: applicationSupportURL.path(percentEncoded: false)) {
+                        try! fileManager.createDirectory(at: applicationSupportURL, withIntermediateDirectories: true)
+                    }
+                }
+                
                 let encoder = PropertyListEncoder()
                 encoder.outputFormat = .binary
                 

--- a/Tests/DocumentDataIntergrationTests/DocumentDataIntergrationTests.swift
+++ b/Tests/DocumentDataIntergrationTests/DocumentDataIntergrationTests.swift
@@ -26,6 +26,7 @@ final class DocumentDataIntergrationTests: XCTestCase {
             ignored: "some"
         )
         print(testCase)
+        testCase.save()
     }
     
     func testDefault() throws {

--- a/Tests/DocumentDataTests/DocumentDataTests.swift
+++ b/Tests/DocumentDataTests/DocumentDataTests.swift
@@ -140,7 +140,15 @@ final class DocumentDataTests: XCTestCase {
                     return decoded[keyPath: keyPath]
                 }
 
-                func save() {
+                func save(autoCreateFolder: Bool = true) {
+                    if autoCreateFolder {
+                        let fileManager = FileManager()
+                        let applicationSupportURL = Self.url.deletingLastPathComponent()
+                        if !fileManager.fileExists(atPath: applicationSupportURL.path(percentEncoded: false)) {
+                            try! fileManager.createDirectory(at: applicationSupportURL, withIntermediateDirectories: true)
+                        }
+                    }
+            
                     let encoder = PropertyListEncoder()
                     encoder.outputFormat = .binary
 
@@ -454,7 +462,15 @@ final class DocumentDataTests: XCTestCase {
                     return decoded[keyPath: keyPath]
                 }
 
-                func save() {
+                func save(autoCreateFolder: Bool = true) {
+                    if autoCreateFolder {
+                        let fileManager = FileManager()
+                        let applicationSupportURL = Self.url.deletingLastPathComponent()
+                        if !fileManager.fileExists(atPath: applicationSupportURL.path(percentEncoded: false)) {
+                            try! fileManager.createDirectory(at: applicationSupportURL, withIntermediateDirectories: true)
+                        }
+                    }
+            
                     let encoder = PropertyListEncoder()
                     encoder.outputFormat = .binary
 


### PR DESCRIPTION
save() function adds the autoCreateFolder parameter, which controls whether non-existing folders are automatically created when you save them.